### PR TITLE
fix: wrong randomText when unicode preset

### DIFF
--- a/captcha.go
+++ b/captcha.go
@@ -186,9 +186,9 @@ func drawWithOption(text string, img *image.NRGBA, options *Options) error {
 }
 
 func randomText(opts *Options) (text string) {
-	n := len(opts.CharPreset)
+	n := len([]rune(opts.CharPreset))
 	for i := 0; i < opts.TextLength; i++ {
-		text += string(opts.CharPreset[rand.Intn(n)])
+		text += string([]rune(opts.CharPreset)[rand.Intn(n)])
 	}
 
 	return text


### PR DESCRIPTION
Hello! 
**case:** when character preset is unicode(cyrillic, chineese, etc..) randomText was loop by byte characters, but unicode has more bytes in one symbol. That's returning a "part of symbol" has no clue.
**example:**
```
preset: АБВ世界YN
[]rune: [1040 1041 1042 19990 30028 89 78]
[]byte: [208 144 208 145 208 146 228 184 150 231 149 140 89 78]
```
Thank You!