### PR TITLE
add float rounder to 15th

### DIFF
--- a/hsva_test.go
+++ b/hsva_test.go
@@ -3,6 +3,7 @@ package captcha
 import (
 	"fmt"
 	"image/color"
+	"math"
 	"testing"
 )
 
@@ -55,7 +56,7 @@ func TestConversionRGB(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var blue1 color.Color = hsva{h: 240.0 / 360.0, s: 0.75, v: 0.8, a: uint8(255)}
+	var blue1 color.Color = hsva{h: fl(240.0 / 360.0), s: 0.75, v: 0.8, a: uint8(255)}
 	var blue2 color.Color = color.RGBA{R: uint8(51), G: uint8(51), B: uint8(204), A: uint8(255)}
 
 	if err := eq(blue1, blue2); err != nil {
@@ -78,4 +79,10 @@ func eq(c0, c1 color.Color) error {
 			r0, g0, b0, a0, r1, g1, b1, a1)
 	}
 	return nil
+}
+
+func fl(n float64) float64 {
+	out := math.Pow10(15)
+	rnd := int(n*out + math.Copysign(0.5, n*out))
+	return float64(rnd) / out
 }


### PR DESCRIPTION
Hello!
case: test case blue cannot be finish by error, causing by float64 dividing, was trow value more that 15th 
error:
```
got  0x3232 0x3333 0xcccc 0xffff
want 0x3333 0x3333 0xcccc 0xffff
```
caused by equasion: 
240.0 / 360.0 = 0.6666666666666666
accepted vallues for "h" in blue:
// 0.666-0.667, 0.666666666666666, 0.666666666666667

solution:
rounding float64 to 15th number after point, tested by other colors

Thank You!